### PR TITLE
Improve enteral volume calculator and expand formula data

### DIFF
--- a/components/enteral-calculator.tsx
+++ b/components/enteral-calculator.tsx
@@ -1560,6 +1560,16 @@ onValueChange={(val: VolumeUnit) => {
       {/* Results */}
       {result && <ResultsCard result={result} />}
       {result && <ResultsSummary result={result} />}
+
+      {/* Clear All button at bottom after results */}
+      {result && (
+        <div className="flex justify-center">
+          <Button onClick={handleReset} variant="outline" size="lg">
+            <RotateCcw className="mr-2 size-4" />
+            Clear All
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/components/enteral-calculator.tsx
+++ b/components/enteral-calculator.tsx
@@ -292,9 +292,13 @@ function DatePickerField({
   const [open, setOpen] = useState(false)
   const [textValue, setTextValue] = useState(value ? format(value, "MM/dd/yyyy") : "")
 
-  // Sync text when calendar picks a date
+  // Sync text when calendar picks a date or when value is cleared
   useEffect(() => {
-    if (value) setTextValue(format(value, "MM/dd/yyyy"))
+    if (value) {
+      setTextValue(format(value, "MM/dd/yyyy"))
+    } else {
+      setTextValue("")
+    }
   }, [value])
 
   // Helper to convert 2-digit year to 4-digit year
@@ -679,15 +683,25 @@ function VolumeCalculator({
   onApply,
   densityType,
   packaging,
+  resetKey,
 }: {
   onApply: (amount: string, unit: VolumeUnit, feedingBreakdown: { amountPerFeeding: number; timesPerDay: number }) => void
   densityType: DensityType
   packaging?: EnteralProduct["packaging"]
+  resetKey?: number
 }) {
   const [open, setOpen] = useState(false)
   const [amountPerFeeding, setAmountPerFeeding] = useState("")
   const [feedingUnit, setFeedingUnit] = useState<VolumeUnit>(densityType === "kcal/g" ? "g" : "mL")
   const [timesPerDay, setTimesPerDay] = useState("")
+
+  // Reset internal state when resetKey changes (triggered by form reset)
+  useEffect(() => {
+    setOpen(false)
+    setAmountPerFeeding("")
+    setTimesPerDay("")
+    setFeedingUnit(densityType === "kcal/g" ? "g" : "mL")
+  }, [resetKey, densityType])
 
   // Sync feedingUnit when densityType changes (only reset to default unit when density type changes)
   useEffect(() => {
@@ -823,8 +837,9 @@ export function EnteralCalculator() {
   const [showDensityOverride, setShowDensityOverride] = useState(false)
   const [densityOverride, setDensityOverride] = useState("")
   const [densityOverrideUnit, setDensityOverrideUnit] = useState<"kcal/mL" | "kcal/oz" | "kcal/g">("kcal/mL")
-  const [feedingBreakdown, setFeedingBreakdown] = useState<{ amountPerFeeding: number; timesPerDay: number; feedingUnit: VolumeUnit } | null>(null)
-
+const [feedingBreakdown, setFeedingBreakdown] = useState<{ amountPerFeeding: number; timesPerDay: number; feedingUnit: VolumeUnit } | null>(null)
+  const [resetKey, setResetKey] = useState(0) // Used to reset CalculateDailyVolume internal state
+  
   // Derived state
   const selectedProduct = useMemo(
     () => ENTERAL_PRODUCTS.find((p) => p.name === formulaName && (p.hcpcsCode === hcpcsCode || p.altHcpcsCode === hcpcsCode)),
@@ -1072,14 +1087,14 @@ export function EnteralCalculator() {
     setDensityOverride("")
     setDensityOverrideUnit("kcal/mL")
     setFeedingBreakdown(null)
-    // Preserve valid date span - only clear if dates are invalid
-    if (!startDate || !endDate || endDate < startDate) {
-      setStartDate(undefined)
-      setEndDate(undefined)
-    }
+    // Always clear dates on reset
+    setStartDate(undefined)
+    setEndDate(undefined)
     setResult(null)
     setErrors([])
-  }, [startDate, endDate])
+    // Increment reset key to force CalculateDailyVolume to reset its internal state
+    setResetKey(prev => prev + 1)
+  }, [])
 
   return (
     <div className={cn("flex flex-col gap-6 w-full max-w-xl mx-auto", result && "calculated")}>
@@ -1367,6 +1382,7 @@ onValueChange={(val: VolumeUnit) => {
                 <VolumeCalculator
                   densityType={selectedProduct?.isPowder ? "kcal/g" : "kcal/mL"}
                   packaging={selectedProduct?.packaging}
+                  resetKey={resetKey}
                   onApply={(amount, unit, breakdown) => {
                     setVolumeAmount(amount)
                     setVolumeUnit(unit)

--- a/lib/enteral-data.ts
+++ b/lib/enteral-data.ts
@@ -329,6 +329,13 @@ export const ENTERAL_PRODUCTS: EnteralProduct[] = [
   { name: "PKU Lophlex LQ", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: 0.6, kcalPerGram: null, packaging: [{ type: "pouch", label: "125 mL pouch", mlPerUnit: 125, kcalPerUnit: 75 }] },
   { name: "PKU Sphere", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: null, kcalPerGram: null, packaging: [{ type: "packet", label: "35g sachet", gramsPerUnit: 35 }] },
   { name: "Phlexy-10 System (PKU)", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: null, kcalPerGram: 3.0, isPowder: true, packaging: [{ type: "packet", label: "20g sachet", gramsPerUnit: 20, kcalPerUnit: 60 }] },
+  // Periflex (Nutricia) - PKU formulas
+  { name: "Periflex Infant (PKU)", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: null, kcalPerGram: 4.7, isPowder: true, packaging: [{ type: "can", label: "400g can", gramsPerUnit: 400 }] },
+  { name: "Periflex Junior (PKU)", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: null, kcalPerGram: 3.9, isPowder: true, packaging: [{ type: "can", label: "400g can", gramsPerUnit: 400 }] },
+  { name: "Periflex Junior Plus (PKU)", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: null, kcalPerGram: 3.9, isPowder: true, packaging: [{ type: "can", label: "400g can", gramsPerUnit: 400 }] },
+  { name: "Periflex Advance (PKU)", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: null, kcalPerGram: 3.4, isPowder: true, packaging: [{ type: "packet", label: "50g sachet", gramsPerUnit: 50, kcalPerUnit: 170 }] },
+  { name: "Periflex LQ 10 (PKU)", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: 0.65, kcalPerGram: null, packaging: [{ type: "pouch", label: "62.5 mL pouch", mlPerUnit: 62.5, kcalPerUnit: 41 }] },
+  { name: "Periflex LQ 20 (PKU)", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: 0.65, kcalPerGram: null, packaging: [{ type: "pouch", label: "125 mL pouch", mlPerUnit: 125, kcalPerUnit: 81 }] },
   { name: "UCD Anamix Junior", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: 0.9, kcalPerGram: 3.9, isPowder: true, packaging: [{ type: "can", label: "400g can", gramsPerUnit: 400 }] },
   { name: "MSUD Anamix Junior", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: null, kcalPerGram: 3.8, isPowder: true, packaging: [{ type: "can", label: "400g can", gramsPerUnit: 400 }] },
   { name: "HCU Anamix", manufacturer: "Nutricia", hcpcsCode: "B4157", kcalPerMl: null, kcalPerGram: 3.8, isPowder: true, packaging: [{ type: "can", label: "400g can", gramsPerUnit: 400 }] },
@@ -350,7 +357,7 @@ export const ENTERAL_PRODUCTS: EnteralProduct[] = [
   { name: "Glytactin RTD 15", manufacturer: "Ajinomoto Cambrooke", hcpcsCode: "B4157", kcalPerMl: 0.52, kcalPerGram: null, packaging: [{ type: "bottle", label: "8.5 fl oz bottle", mlPerUnit: 250, kcalPerUnit: 130 }] },
   { name: "Glytactin Complete", manufacturer: "Ajinomoto Cambrooke", hcpcsCode: "B4157", kcalPerMl: null, kcalPerGram: null, packaging: [{ type: "packet", label: "34g packet", gramsPerUnit: 34 }] },
 
-  // ════════════════════════��════��══════════════════════════════════════���═══���═════
+  // ═══════════════════���════��════��══════════════════════════════════════���═══���═════
   // B4158: Pediatric, intact nutrients
   // ══════════════════════════════════════════════════════════════����═══════════════
   // Abbott


### PR DESCRIPTION
- Enhanced reset functionality to clear all input fields, dates, and calculated values simultaneously.
- Added a secondary "Clear All" button visible at the bottom of the page after results are generated.
- Expanded enteral data library to include Periflex formula variants for B4157.

[v0 Session](https://v0.app/chat/77Blwm6ayvO)